### PR TITLE
Fix: API Key 숨김 처리

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-kapt'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {
@@ -84,6 +85,7 @@ dependencies {
     // 카카오 로그인 관련 API
     implementation "com.kakao.sdk:v2-user:2.12.1" // 카카오 로그인
 
+    //Unit Test
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -94,8 +94,9 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
 
                 <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
-                <data android:host="oauth"
-                    android:scheme="kakao92bf853f239ace67c04e56eece5f31ba" />
+                <data
+                    android:host="oauth"
+                    android:scheme="${KAKAO_APP_KEY}" />
 
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/example/farmus_application/ui/farm/FarmFragment.kt
+++ b/app/src/main/java/com/example/farmus_application/ui/farm/FarmFragment.kt
@@ -55,7 +55,7 @@ class FarmFragment : Fragment() {
         val tabLayout = farmBinding.tabLayout
 
 
-        viewPager.adapter = ViewPagerAdapter(childFragmentManager,lifecycle)
+        //viewPager.adapter = ViewPagerAdapter(childFragmentManager,lifecycle)
 
         TabLayoutMediator(tabLayout, viewPager) { tab, position ->
             tab.text = tabTitleArray[position]

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,7 +11,16 @@
     <string name="navi_mypage">마이페이지</string>
     <string name="navi_chat">채팅</string>
     <string name="search_bar_hint_text">닉네임 또는 농장 이름을 입력하세요.</string>
+
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
+
+    <!-- TODO: link-failed 해결을 위한 임시 텍스트 -->
+    <string name="copy_my_id"> </string>
+    <string name="click_to_singup"> </string>
+    <string name="terms_payment"> </string>
+    <string name="term_uses"> </string>
+    <string name="terms_location"> </string>
+    <string name="term_personal_info"> </string>
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+buildscript {
+    dependencies {
+        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
+    }
+}
+
 plugins {
     id 'com.android.application' version '7.3.1' apply false
     id 'com.android.library' version '7.3.1' apply false


### PR DESCRIPTION
## 구현한 기능
[google/secret-gradle-plugin](https://github.com/google/secrets-gradle-plugin)을 사용하여 
local.properties에 작성한 API key를 쉽게 manifest의 `android:value`field 와 BuildConfig로 가져올 수 있게 함.

## 사용한 라이브러리 및 Class
[google/secret-gradle-plugin](https://github.com/google/secrets-gradle-plugin)

## 핵심 Code
### build.gradle(:project)
```gradle
buildscript {
    dependencies {
        classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
    }
}
```

### build.gradle(:app)
```gradle
plugins {
    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
}
```

## 개선할 점
크게 없어 보임.