### PR TITLE
Correct : UserRepository에 UserDataSource를 상속하는 것 제거

### DIFF
--- a/app/src/main/java/com/example/farmus_application/repository/user/UserRepository.kt
+++ b/app/src/main/java/com/example/farmus_application/repository/user/UserRepository.kt
@@ -17,43 +17,43 @@ import retrofit2.Response
 
 class UserRepository(
     private val userApiClient: UserApiClient = ServiceLocator.userApiClient
-): UserDataSource {
+) {
 
-    override suspend fun postUserSignup(params: SignUpReq): Response<SignUpRes> {
+    suspend fun postUserSignup(params: SignUpReq): Response<SignUpRes> {
         return userApiClient.postSignUp(params = params)
     }
 
-    override suspend fun postUserLogin(params: LoginReq): Response<LoginRes> {
+    suspend fun postUserLogin(params: LoginReq): Response<LoginRes> {
         return userApiClient.postLogin(params = params)
     }
 
-    override suspend fun postUserSignupVerification(params : SignUpVerificationReq): Response<SignUpVerificationRes> {
+    suspend fun postUserSignupVerification(params : SignUpVerificationReq): Response<SignUpVerificationRes> {
         return userApiClient.postUserSignupVerification(params = params)
     }
 
-    override suspend fun postUserVerification(params : VerificationReq): Response<VerificationRes> {
+    suspend fun postUserVerification(params : VerificationReq): Response<VerificationRes> {
         return userApiClient.postUserVerification(params = params)
     }
 
     // == get과 patch에 대한
-    override suspend fun getUserFindAccount(name : String, phoneNumber : String): Response<FindAccountRes> {
+    suspend fun getUserFindAccount(name : String, phoneNumber : String): Response<FindAccountRes> {
         return userApiClient.getUserFindAccount(name = name, phoneNumber = phoneNumber)
     }
 
-    override suspend fun getUserFindPassword(userEmail : String): Response<FindPasswordRes> {
+    suspend fun getUserFindPassword(userEmail : String): Response<FindPasswordRes> {
         return userApiClient.getUserFindPassword(userEmail = userEmail)
     }
 
-    override suspend fun patchUserWithdrawal(userEmail: String): Response<WithdrawalRes>{
+    suspend fun patchUserWithdrawal(userEmail: String): Response<WithdrawalRes>{
         return userApiClient.patchUserWithdrawal(userEmail = userEmail)
     }
 
-//    override suspend fun postUserStarFarmid(params : StarFarmidReq): StarFarmidRes {
+//    suspend fun postUserStarFarmid(params : StarFarmidReq): StarFarmidRes {
 //        return userApiClient.postUserStarFarmid(params = params)
 //    }
 
 
-//    override suspend fun postUserBirth(params : BirthReq): BirthRes {
+//    suspend fun postUserBirth(params : BirthReq): BirthRes {
 //        return userApiClient.postUserBirth(params = params)
 //    }
 


### PR DESCRIPTION
## 변경 내용
최근 MVVM 아키텍처 패턴에 적용한 Repository 패턴을 많이 찾아본 결과 저희의 DataSource 쓰임이 잘못된 것 같습니다.
UseRepository class가 UserDataSource interface를 상속받았지만, 이는 UserRepository 인터페이스로 받아 그냥 같은 코드를 두번 작성한 것일 뿐 DataSource의 의미가 없는 것같습니다.<br>
<b>결론적으로, 제가 수정한 부분은 UserRepository가 UserDataSource interface를 상속받는 것을 제거하고 그에 따라 override 키워드를 지웠습니다. 작동은 기존과 동일하게 정상 작동 합니다.</b> 
잡아놓으신 폴더 구조를 제가 실수로 깨버릴까봐 UserDataSource interface는 삭제하지 않았습니다. 추가적으로 찾아보면서 말씀드리고 변경해보겠습니다.

## 계속 찾아보고 있는 중인 Data Source 사용법 및 Repository Pattern.
[안드로이드 Data Layer 문서](https://developer.android.com/topic/architecture/data-layer?hl=ko) 여기서 중간에 예제를 보면 아래와 같은 코드가 있습니다.
```
class ExampleRepository(private val exampleRemoteDataSource : ExampleRemoteDataSource, // network
       private val exampleLocalDataSource : ExampleLocalDataSource // database
) { /*... */}
```
어떤 data를 다루는 datasource들을 어떤 하나의 동작을 하는 Repository로 모으는 방식인 것 같습니다.<br>
data class A, data class B가 있다고 할 때, datasource는 Retrofit 관련 API 등을 받아서 실행하는 동작이 들어가고, Repository는 해당 datasource를 받아서 datasource 내의 것을 실행하는 것 같습니다.<br>

부족한 점이 많아 잘 이해하진 못했지만, 여러 참고 코드들을 찾아본 결과 datasource가 전부 class로 구현되어 Repository에 넘겨지는 방식이었습니다.
## 참고자료들
[직접 적인 login 구현을 repository MVVM 패턴으로 한 github 코드](https://github.com/muhammadAriefHidayat/Login-Register-MVVM-Retrofit/blob/master/app/src/main/java/com/apps/loginregisterretrofit/data/datastore/RemoteDataSource.kt)
[datasource의 종류에 대한 글](https://medium.com/swlh/defining-data-sources-in-clean-architecture-android-f0ee7cbc6634)
[repository pattern글](https://jcchu.medium.com/repository-pattern%EC%97%90-%EB%8C%80%ED%95%B4-%EC%95%8C%EC%95%84%EB%B3%B4%EA%B8%B0-c86407d487cf)
[repository pattern 사용 예시](https://rodrigo-silva96.medium.com/android-repository-pattern-using-room-retrofit-and-coroutines-c6a217e32f80)
## 확인 후에 merge 시켜주셔도 괜찮고 아니여도 정말 괜찮습니다!

