### PR TITLE
EncryptedSharedPreferences 기반 UserDataStorage 추가 및 로그인, 로그아웃 로직 수정 및 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     // Database
     implementation "androidx.room:room-runtime:$roomVersion"
     implementation "androidx.room:room-ktx:$roomVersion"
+    implementation 'androidx.security:security-crypto-ktx:1.1.0-alpha03'
     kapt "androidx.room:room-compiler:$roomVersion"
 
     // Kotlin

--- a/app/src/main/java/com/example/farmus_application/MyApplication.kt
+++ b/app/src/main/java/com/example/farmus_application/MyApplication.kt
@@ -2,6 +2,7 @@ package com.example.farmus_application
 
 import android.app.Application
 import android.content.Context
+import com.example.farmus_application.repository.UserPrefsStorage
 import com.kakao.sdk.common.KakaoSdk
 
 class MyApplication : Application() {
@@ -20,6 +21,7 @@ class MyApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        UserPrefsStorage.init(this)
         KakaoSdk.init(this, "92bf853f239ace67c04e56eece5f31ba")
     }
 }

--- a/app/src/main/java/com/example/farmus_application/repository/UserPrefsStorage.kt
+++ b/app/src/main/java/com/example/farmus_application/repository/UserPrefsStorage.kt
@@ -1,0 +1,69 @@
+package com.example.farmus_application.repository
+
+import android.content.Context
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import kotlinx.coroutines.delay
+
+object UserPrefsStorage {
+    private lateinit var prefs: EncryptedSharedPreferences
+
+    fun init(context: Context) {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        prefs = EncryptedSharedPreferences.create(
+            context,
+            "user_prefs",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        ) as EncryptedSharedPreferences
+    }
+
+    var accessToken: String?
+        get() = prefs.getString("access_token", null)
+        set(value) = prefs.edit().putString("access_token", value).apply()
+
+    var refreshToken: String?
+        get() = prefs.getString("refresh_token", null)
+        set(value) = prefs.edit().putString("refresh_token", value).apply()
+
+    var name: String?
+        get() = prefs.getString("user_name", null)
+        set(value) = prefs.edit().putString("user_name", value).apply()
+
+    var nickName: String?
+        get() = prefs.getString("user_nickName", null)
+        set(value) = prefs.edit().putString("user_nickName", value).apply()
+
+    var email: String?
+        get() = prefs.getString("user_email", null)
+        set(value) = prefs.edit().putString("user_email", value).apply()
+
+    var role: String?
+        get() = prefs.getString("user_role", null)
+        set(value) = prefs.edit().putString("user_role", value).apply()
+
+    suspend fun clearStorage() {
+        prefs.edit().clear().apply()
+    }
+
+//    suspend fun setUserData(
+//        accessToken: String?,
+//        refreshToken: String?,
+//        name: String?,
+//        nickName: String?,
+//        email: String?,
+//        role: String?
+//    ) {
+//        this.accessToken = accessToken
+//        this.refreshToken = refreshToken
+//        this.name = name
+//        this.nickName = nickName
+//        this.email = email
+//        this.role = role
+//    }
+}

--- a/app/src/main/java/com/example/farmus_application/ui/account/AccountSettingFragment.kt
+++ b/app/src/main/java/com/example/farmus_application/ui/account/AccountSettingFragment.kt
@@ -1,15 +1,20 @@
 package com.example.farmus_application.ui.account
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
+import androidx.lifecycle.ViewModelProvider
 import com.example.farmus_application.R
 import com.example.farmus_application.databinding.FragmentAccountSettingBinding
+import com.example.farmus_application.repository.UserPrefsStorage
 import com.example.farmus_application.ui.MainActivity
+import com.example.farmus_application.ui.StartActivity
+import com.example.farmus_application.viewmodel.account.AccountSettingViewModel
 
 // TODO: Rename parameter arguments, choose names that match
 // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
@@ -26,6 +31,7 @@ class AccountSettingFragment : Fragment() {
     private lateinit var binding : FragmentAccountSettingBinding
     //뒤로가기 기능 구현
     private lateinit var callback: OnBackPressedCallback
+    private lateinit var viewModel: AccountSettingViewModel
 
     // TODO: Rename and change types of parameters
     private var param1: String? = null
@@ -50,6 +56,7 @@ class AccountSettingFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(this).get(AccountSettingViewModel::class.java)
 
         binding.toolbar.toolbarMainTitleText.apply {
             text = "설정"
@@ -57,6 +64,16 @@ class AccountSettingFragment : Fragment() {
         //툴바 백터튼 누르면 MyPageFragment로 이동
         binding.toolbar.toolbarWithTitleBackButton.setOnClickListener {
             (activity as MainActivity).changeFragment(MyPageFragment.newInstance("",""))
+        }
+
+        //로그아웃 버튼
+        binding.layerLogout.setOnClickListener{
+            //Datastore(로그인 유저정보) 비우기
+            viewModel.clearUserData()
+
+            val intent = Intent(requireContext(), StartActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            startActivity(intent)
         }
     }
 

--- a/app/src/main/java/com/example/farmus_application/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/farmus_application/ui/login/LoginActivity.kt
@@ -19,6 +19,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import com.example.farmus_application.databinding.ActivityLoginMainBinding
 import com.example.farmus_application.model.user.login.LoginReq
+import com.example.farmus_application.repository.UserPrefsStorage
 import com.example.farmus_application.ui.MainActivity
 import com.example.farmus_application.ui.StartActivity
 import com.example.farmus_application.viewmodel.login.LoginViewModel
@@ -28,6 +29,7 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.common.model.KakaoSdkError
 import com.kakao.sdk.user.UserApiClient
+import java.security.AccessController.getContext
 import java.util.regex.Pattern
 
 class LoginActivity : AppCompatActivity() {
@@ -125,12 +127,13 @@ class LoginActivity : AppCompatActivity() {
                 email = editTextID.text.toString(),
                 password = editTextPW.text.toString()
             )
+            viewModel.setUserData(null)
 
             viewModel.userLogin(params)
         }
 
         viewModel.loginResponse.observe(this, Observer {
-            //todo : LoginResult의 토큰 저장 및 앱 초기실행시 토큰 검사를 통해 자동로그인 로직 작성
+            viewModel.setUserData(it)
 
             val startActivity = StartActivity.getInstance()
             startActivity?.let { it.finish() }

--- a/app/src/main/java/com/example/farmus_application/viewmodel/account/AccountSettingViewModel.kt
+++ b/app/src/main/java/com/example/farmus_application/viewmodel/account/AccountSettingViewModel.kt
@@ -1,0 +1,17 @@
+package com.example.farmus_application.viewmodel.account
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.farmus_application.repository.UserPrefsStorage
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class AccountSettingViewModel() : ViewModel() {
+    private val TAG = "AccountSettingViewModel"
+
+    fun clearUserData() {
+        viewModelScope.launch(Dispatchers.IO) {
+            UserPrefsStorage.clearStorage()
+        }
+    }
+}

--- a/app/src/main/java/com/example/farmus_application/viewmodel/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/farmus_application/viewmodel/login/LoginViewModel.kt
@@ -7,7 +7,10 @@ import androidx.lifecycle.viewModelScope
 import com.example.farmus_application.model.user.login.LoginReq
 import com.example.farmus_application.model.user.login.LoginRes
 import com.example.farmus_application.model.user.login.LoginResult
+import com.example.farmus_application.repository.UserPrefsStorage
 import com.example.farmus_application.repository.user.UserRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
@@ -50,6 +53,29 @@ class LoginViewModel() : ViewModel(){
                 }
             } catch (e: Exception) {
                 e.printStackTrace()
+            }
+        }
+    }
+
+    fun setUserData(params: LoginResult?) {
+        viewModelScope.launch(Dispatchers.IO) {
+            UserPrefsStorage.let {
+                it.accessToken = params?.accesstoken
+                it.refreshToken = null
+                it.name = params?.name
+                it.nickName = params?.nickName
+                it.email = params?.email
+                it.role = params?.role
+
+                // 이 구조로 데이터 삽입시 정상 삽입이 안됨.
+//                UserPrefsStorage.setUserData(
+//                    accessToken = it.accesstoken,
+//                    refreshToken = null,
+//                    name = it.name,
+//                    nickName = it.nickName,
+//                    email = it.email,
+//                    role = it.role
+//                )
             }
         }
     }


### PR DESCRIPTION
## 구현한 기능
UserData를 관리하는 Storage 추가 ( /repository/UserPrefsStorage )

로그인 로직 수정 (로그인 시 response된 UserData를 모두 저장)

로그아웃 로직 추가 (StartActivity로 복귀 및 저장된 UserData 모두 초기화)
## 사용한 라이브러리 및 Class
EncryptedSharedPreferences
## 핵심 Code
UserPrefsStorage
## 개선할 점
ViewModel 에서 UserPrefsStorage의 변수 setter를 다이렉트 호출하면 정상적으로 데이터 기입이 되지만
UserPrefsStorage 내에서 해당 로직을 함수화 시킨 후 ViewModel에서 해당 함수를 호출하면 데이터가 기입되지 않음.
전자의 내용대로 사용하여도 아무 문제는 없으나, 후자의 경우가 더 클린코드가 될 수 있기에 혹여 이유를 찾아주신다면 감사...