### PR TITLE
좋아요 탭바 부분 + MyPage 부분 임시 처리

### DIFF
--- a/app/src/main/java/com/example/farmus_application/ui/account/ProfileSettingFragment.kt
+++ b/app/src/main/java/com/example/farmus_application/ui/account/ProfileSettingFragment.kt
@@ -82,6 +82,9 @@ class ProfileSettingFragment : Fragment() {
             (activity as MainActivity).changeFragment(MyPageFragment.newInstance("", ""))
         }
 
+        // TODO : 23년 8월 3일(목) 회의에서 아직 기능이 없으므로 가리기로 함.
+        binding.layoutIntroduction.visibility = View.GONE
+
         val userEmail : String = tokenBody.email
         val userNickname = tokenBody.nickName
         val userName = tokenBody.name

--- a/app/src/main/java/com/example/farmus_application/ui/favorite/adapter/FavoriteRVAdapter.kt
+++ b/app/src/main/java/com/example/farmus_application/ui/favorite/adapter/FavoriteRVAdapter.kt
@@ -21,6 +21,7 @@ class FavoriteRVAdapter : ListAdapter<FavoriteFarm, FavoriteRVAdapter.ViewHolder
     val email = JWTUtils.decoded(jwtToken.toString())?.tokenBody?.email
 
     interface OnItemClickListener {
+        fun itemClick(farmId: Int)
         fun likeClick(email : String, farmId : Int)
         fun deleteLikeClick(email : String, farmId : Int)
     }
@@ -55,7 +56,9 @@ class FavoriteRVAdapter : ListAdapter<FavoriteFarm, FavoriteRVAdapter.ViewHolder
                 }
             }
 
-            // TODO : item click event 관련
+            binding.root.setOnClickListener {
+                listener?.itemClick(item.FarmID)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/farmus_application/viewmodel/favorite/FavoriteViewModel.kt
+++ b/app/src/main/java/com/example/farmus_application/viewmodel/favorite/FavoriteViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.farmus_application.model.favorite.FavoriteFarm
+import com.example.farmus_application.model.favorite.FavoriteFarmRes
 import com.example.farmus_application.model.user.likes.LikeFarmReq
 import com.example.farmus_application.repository.farm.FarmRepository
 import com.example.farmus_application.repository.user.UserRepository
@@ -17,15 +18,14 @@ class FavoriteViewModel : ViewModel() {
     private val farmRepo = FarmRepository()
     private val userRepo = UserRepository()
 
-    private val _favoriteFarmList: MutableLiveData<List<FavoriteFarm>> = MutableLiveData()
-    val favoriteFarmList: LiveData<List<FavoriteFarm>> = _favoriteFarmList
+
+    private val _favoriteFarmResponse : MutableLiveData<FavoriteFarmRes> = MutableLiveData()
+    val favoriteFarmResponse : LiveData<FavoriteFarmRes> = _favoriteFarmResponse
 
     private val _isLikeFarmSuccess: MutableLiveData<Boolean> = MutableLiveData()
     val isLikeFarmSuccess: LiveData<Boolean> = _isLikeFarmSuccess
     private val _isDeleteLikeFarmSuccess: MutableLiveData<Boolean> = MutableLiveData()
     val isDeleteLikeFarmSuccess: LiveData<Boolean> = _isDeleteLikeFarmSuccess
-    private val _farmListSize : MutableLiveData<Int> = MutableLiveData()
-    val farmListSize : LiveData<Int> = _farmListSize
 
     fun getFavoriteFarmList(email: String) {
         viewModelScope.launch {
@@ -51,11 +51,10 @@ class FavoriteViewModel : ViewModel() {
                                     )
                                 )
                             }
-                            _favoriteFarmList.postValue(favoriteFarmList)
-                            _farmListSize.postValue(favoriteFarmList.size)
+                            _favoriteFarmResponse.postValue(it)
                         } else {
+                            _favoriteFarmResponse.postValue(it)
                             Log.d("FavoriteFarmList result failed : ", response.body().toString())
-                            _farmListSize.postValue(0)
                         }
                     }
                 } else {

--- a/app/src/main/res/layout/fragment_favorite.xml
+++ b/app/src/main/res/layout/fragment_favorite.xml
@@ -34,5 +34,17 @@
             android:layout_marginTop="9dp"
             />
 
+        <!-- fragment_search 부분과 같은 곳으로 연결시켜놓음-->
+        <include
+            android:id="@+id/empty_data_parent"
+            layout="@layout/item_empty_datset"
+            android:layout_width="wrap_content"
+            android:layout_height ="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tool_bar"
+            android:layout_margin="9dp"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_my_page.xml
+++ b/app/src/main/res/layout/fragment_my_page.xml
@@ -49,7 +49,7 @@
                     android:layout_width="70dp"
                     android:layout_height="70dp"
                     android:background="@color/gray_2"
-                     />
+                    android:scaleType="centerCrop" />
 
             </androidx.cardview.widget.CardView>
 
@@ -93,13 +93,14 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <!-- text 부분에 채울 문구 임시로 ""처리. 전체 주석을 걸지 않은 것은 UI가 너무 좁아지기 때문.-->
             <TextView
                 style="@style/Body2Reg"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="23dp"
                 android:layout_marginBottom="19dp"
-                android:text="안녕하세요. 치룬입니다. 즐거운 농장 생활해요 -!"
+                android:text=""
                 android:textColor="@color/text_1"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/fragment_profile_setting.xml
+++ b/app/src/main/res/layout/fragment_profile_setting.xml
@@ -124,6 +124,7 @@
                     </androidx.constraintlayout.widget.ConstraintLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/layout_introduction"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="38dp">

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -78,7 +78,8 @@
                     android:layout_height="wrap_content"
                     android:visibility="gone"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/chip_region_filter" />
+                    app:layout_constraintTop_toBottomOf="@+id/chip_region_filter"
+                    android:layout_margin="9dp"/>
 
 
 


### PR DESCRIPTION
## 구현한 기능
- '좋아요'부분 item click event → farm detail page로 넘어감
- '좋아요'부분. 찜한 농장이 아무것도 없을 때 임시 출력 문구 작성(home의 searchFragment와 같은 xml을 참조하기 때문에 추후에 디자인에 따라서 변경할 필요성 있음)
- '마이페이지'부분 한 줄 소개 관련 주석처리, '마이페이지-설정'부분에서도 코드창에 visibility gone 처리 (나중에 UI와 함께 움직일 것)
- '마이페이지' profile image 부분에 scale옵션 center crop 적용