### PR TITLE
MODIFY : https 적용에 따른 SSLPeerUnversifiedExcept 발생 ->우회 적용

### DIFF
--- a/app/src/main/java/com/farm/farmus_application/network/BaseApiClient.kt
+++ b/app/src/main/java/com/farm/farmus_application/network/BaseApiClient.kt
@@ -1,5 +1,6 @@
 package com.farm.farmus_application.network
 
+import android.util.Log
 import com.farm.farmus_application.repository.UserPrefsStorage
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
@@ -7,11 +8,16 @@ import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
 
 interface BaseApiClient {
 
     companion object {
-        private const val baseUrl = "http://118.67.135.247:3000/"
+        private const val baseUrl = "https://118.67.135.247/"
         private val jwtToken = UserPrefsStorage.accessToken ?: ""
 
         fun create(): Retrofit {
@@ -19,7 +25,7 @@ interface BaseApiClient {
                 level = HttpLoggingInterceptor.Level.BASIC
             }
 
-            val client = OkHttpClient.Builder()
+            val client = unsafeOkHttpClient()
                 .addInterceptor(logger)
                 .addInterceptor(AppInterceptor())
                 .build()
@@ -31,8 +37,43 @@ interface BaseApiClient {
                 .build()
         }
 
+        private fun unsafeOkHttpClient(): OkHttpClient.Builder {
+            val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
+                override fun checkClientTrusted(
+                    chain: Array<out java.security.cert.X509Certificate>?,
+                    authType: String?
+                ) {
+
+                }
+
+                override fun checkServerTrusted(
+                    chain: Array<out java.security.cert.X509Certificate>?,
+                    authType: String?
+                ) {
+
+                }
+
+                override fun getAcceptedIssuers(): Array<out java.security.cert.X509Certificate>? {
+                    return arrayOf()
+                }
+            })
+
+            val sslContext = SSLContext.getInstance("SSL")
+            sslContext.init(null, trustAllCerts, SecureRandom())
+
+            val sslSocketFactory = sslContext.socketFactory
+
+
+            val builder = OkHttpClient.Builder()
+            builder.sslSocketFactory(sslSocketFactory, trustAllCerts[0] as X509TrustManager)
+            builder.hostnameVerifier { hostname, session -> true }
+
+            return builder
+        }
+
         class AppInterceptor : Interceptor {
             override fun intercept(chain: Interceptor.Chain): Response {
+                Log.d("BASEAPICLIENT", "token : ${jwtToken.toString()}")
                 val newRequest = chain.request().newBuilder()
                     .addHeader("token", jwtToken.toString())
                 return chain.proceed(newRequest.build())


### PR DESCRIPTION
## 구현한 기능
javax.net.ssl.SSLPeerUnverifiedExcept…ion: Hostname not verified 라는 오류가 발생했습니다.
ssl 인증서가 없어서 신뢰할 수 없는 사이트를 접속하는 오류라는 의미입니다.
이에 대한 처리로 ssl 인증서 없이 https로 우회해 통신하는 처리 작성.

저는 참고자료에서 2번을 보고 거의 그대로 이용했습니다. 그런데, 1번도 ssl 키가 없는 경우에 대해서는 2번과 동일하게 적어놓은 것 같습니다.

## 사용한 라이브러리 및 Class
Network 폴더의 BaseAPI Class

## 핵심 Code
## 참고자료
[1번 : SSL key가 있을 때&없을 때](https://namjackson.tistory.com/26)
[2번 : SSL key가 없을 때](https://velog.io/@minhyuuk/Android-javax.net.ssl.SSLPeerUnverifiedException-Hostname-not-verified-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)
