### PR TITLE
채팅부분 전반적인 View

### DIFF
--- a/app/src/main/java/com/farm/farmus_application/ui/message/ChatBottomSheetFragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/ChatBottomSheetFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import com.farm.farmus_application.databinding.FragmentBottomSheetChatBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class BottomSheetFragment() : BottomSheetDialogFragment() {
+class ChatBottomSheetFragment : BottomSheetDialogFragment() {
 
     private lateinit var binding: FragmentBottomSheetChatBinding
 
@@ -15,8 +15,16 @@ class BottomSheetFragment() : BottomSheetDialogFragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentBottomSheetChatBinding.inflate(layoutInflater, container, false)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        // 뷰 초기화 이벤트 수행
+        binding.btnClose.setOnClickListener {
+            dismiss()
+        }
     }
 }

--- a/app/src/main/java/com/farm/farmus_application/ui/message/ChatFragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/ChatFragment.kt
@@ -12,16 +12,10 @@ import com.farm.farmus_application.databinding.FragmentChatBinding
 import com.farm.farmus_application.ui.message.adapter.ChatViewPagerAdapter
 import com.google.android.material.tabs.TabLayoutMediator
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [ChatFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ChatFragment : Fragment() {
 
     private lateinit var chatFragmentBinding: FragmentChatBinding
@@ -31,7 +25,7 @@ class ChatFragment : Fragment() {
         "요청 온 목록"
     )
 
-    // TODO: Rename and change types of parameters
+
     private var param1: String? = null
     private var param2: String? = null
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -69,15 +63,6 @@ class ChatFragment : Fragment() {
     }
 
     companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ChatFragment.
-         */
-        // TODO: Rename and change types and number of parameters
         @JvmStatic
         fun newInstance(param1: String, param2: String) =
             ChatFragment().apply {

--- a/app/src/main/java/com/farm/farmus_application/ui/message/ChatMessage.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/ChatMessage.kt
@@ -1,0 +1,9 @@
+package com.farm.farmus_application.ui.message
+
+// UI만 확인용으로 임시 구현 (나중에 통신부와 맞추어서 변경해야함)
+data class ChatMessage(
+    val senderId : String,
+    val receiverId : String,
+    val message : String,
+    val dateTime : String
+)

--- a/app/src/main/java/com/farm/farmus_application/ui/message/ChatTab1Fragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/ChatTab1Fragment.kt
@@ -1,32 +1,32 @@
 package com.farm.farmus_application.ui.message
 
+import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.farm.farmus_application.R
 import com.farm.farmus_application.databinding.FragmentChatTab1Binding
+import com.farm.farmus_application.ui.MainActivity
 import com.farm.farmus_application.ui.message.adapter.ChatTab1RVAdapter
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [ChatTab1Fragment.newInstance] factory method to
- * create an instance of this fragment.
- */
+
 class ChatTab1Fragment : Fragment() {
+    private val TAG = "ChatTab1FragmentTAG"
 
-    private lateinit var binding : FragmentChatTab1Binding
-    private lateinit var adapter : ChatTab1RVAdapter
+    private lateinit var binding: FragmentChatTab1Binding
+    private lateinit var adapter: ChatTab1RVAdapter
 
-    // TODO: Rename and change types of parameters
+
     private var param1: String? = null
     private var param2: String? = null
 
@@ -41,36 +41,68 @@ class ChatTab1Fragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         // Inflate the layout for this fragment
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_chat_tab1, container, false)
         val view = binding
 
         adapter = ChatTab1RVAdapter()
+        // adatper 내부에 있는 요소들 클릭 이벤트 (어뎁터 안의 interface 명세도 변경 필요)
+        adapter.setOnItemClick(object : ChatTab1RVAdapter.OnItemClickListener {
+            override fun itemClick() {
+                // 필요시 bundle 추가
+                val clientChatFragment = ClientChatFragment()
+                (activity as MainActivity).changeFragmentAddToBackStack(clientChatFragment)
+            }
+        })
+
         val requestItem = mutableListOf<RVTab1DataModel>()
         view.rvChatTab1.adapter = adapter
         adapter.submitList(requestItem)
         view.rvChatTab1.layoutManager = LinearLayoutManager(requireContext())
-        requestItem.add(RVTab1DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        requestItem.add(RVTab1DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        requestItem.add(RVTab1DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        requestItem.add(RVTab1DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        requestItem.add(RVTab1DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
+        requestItem.add(
+            RVTab1DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        requestItem.add(
+            RVTab1DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        requestItem.add(
+            RVTab1DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        requestItem.add(
+            RVTab1DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        requestItem.add(
+            RVTab1DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
 
 
         return view.root
     }
 
+
     companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ChatTab1Fragment.
-         */
-        // TODO: Rename and change types and number of parameters
+
         @JvmStatic
         fun newInstance(param1: String, param2: String) =
             ChatTab1Fragment().apply {

--- a/app/src/main/java/com/farm/farmus_application/ui/message/ChatTab2Fragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/ChatTab2Fragment.kt
@@ -9,27 +9,21 @@ import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.farm.farmus_application.R
 import com.farm.farmus_application.databinding.FragmentChatTab2Binding
+import com.farm.farmus_application.ui.MainActivity
 import com.farm.farmus_application.ui.message.adapter.ChatTab2ApprovedRVAdapter
 import com.farm.farmus_application.ui.message.adapter.ChatTab2RVAdapter
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+
 private const val ARG_PARAM1 = "param1"
 private const val ARG_PARAM2 = "param2"
 
-/**
- * A simple [Fragment] subclass.
- * Use the [ChatTab2Fragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ChatTab2Fragment : Fragment() {
 
     private lateinit var binding: FragmentChatTab2Binding
 
-    private lateinit var tab2Adapter : ChatTab2RVAdapter
-    private lateinit var tab2ApprovedAdapter : ChatTab2ApprovedRVAdapter
+    private lateinit var tab2Adapter: ChatTab2RVAdapter
+    private lateinit var tab2ApprovedAdapter: ChatTab2ApprovedRVAdapter
 
-    // TODO: Rename and change types of parameters
     private var param1: String? = null
     private var param2: String? = null
 
@@ -44,11 +38,9 @@ class ChatTab2Fragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
+    ): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_chat_tab2, container, false)
         val view = binding
-
         return view.root
     }
 
@@ -57,38 +49,98 @@ class ChatTab2Fragment : Fragment() {
 
         val waitItem = mutableListOf<RVTab2DataModel>()
         tab2Adapter = ChatTab2RVAdapter()
+        // adatper 내부에 있는 요소들 클릭 이벤트( 어뎁터 안의 interface 명세도 수정 필요)
+        tab2Adapter.setOnItemClick(object : ChatTab2RVAdapter.OnItemClickListener {
+            override fun itemClick() {
+                // 필요시 bundle 등 추가
+                val farmerChatFragment = FarmerChatFragment()
+                (activity as MainActivity).changeFragmentAddToBackStack(farmerChatFragment)
+            }
+        })
+
         tab2Adapter.submitList(waitItem)
         binding.rvChatWait.adapter = tab2Adapter
         binding.rvChatWait.layoutManager = LinearLayoutManager(requireContext())
-        waitItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        waitItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        waitItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        waitItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        waitItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
+        waitItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        waitItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        waitItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        waitItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        waitItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
 
         val approveItem = mutableListOf<RVTab2DataModel>()
         tab2ApprovedAdapter = ChatTab2ApprovedRVAdapter()
         tab2ApprovedAdapter.submitList(approveItem)
         binding.rvChatApprove.adapter = tab2ApprovedAdapter
         binding.rvChatApprove.layoutManager = LinearLayoutManager(requireContext())
-        approveItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        approveItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        approveItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        approveItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
-        approveItem.add(RVTab2DataModel(R.drawable.farm_image_example, "서울 유일 농장", "2023.02.03~2023.05.07"))
+        approveItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        approveItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        approveItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        approveItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
+        approveItem.add(
+            RVTab2DataModel(
+                R.drawable.farm_image_example,
+                "서울 유일 농장",
+                "2023.02.03~2023.05.07"
+            )
+        )
 
     }
 
     companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ChatTab2Fragment.
-         */
-        // TODO: Rename and change types and number of parameters
         @JvmStatic
         fun newInstance(param1: String, param2: String) =
             ChatTab2Fragment().apply {

--- a/app/src/main/java/com/farm/farmus_application/ui/message/ClientChatFragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/ClientChatFragment.kt
@@ -1,0 +1,119 @@
+package com.farm.farmus_application.ui.message
+
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import android.widget.PopupMenu
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.farm.farmus_application.R
+import com.farm.farmus_application.databinding.FragmentClientChatBinding
+import com.farm.farmus_application.ui.MainActivity
+import com.farm.farmus_application.ui.message.adapter.ClientChatRVAdapter
+
+
+class ClientChatFragment : Fragment() {
+    private val TAG = "ClientChatFragmentTAG"
+    private var _binding: FragmentClientChatBinding? = null
+    private val binding get() = _binding!!
+
+    // TODO : 임시 데이터. 사용 예시
+    private val chatMessages = ArrayList<ChatMessage>().apply {
+        // senderId 와 receivedId가 "0", "0"일 때는 날짜 업데이트를 하게 구현되어있음(rvAdapter와 함께 봐야함)
+        // 기능 구현시 그 부분을 고려해서 수정필요.
+        add(ChatMessage("0", "0", "2023년 01월 08일", "00:00"))
+
+        // 일반 대화 임시 데이터
+        add(ChatMessage("1", "2", "1이 2한테 보냄", "03:00"))
+        add(ChatMessage("2", "1", "2가 1한테 보냄", "03:01"))
+    }
+    private lateinit var clientChatRVAdapter: ClientChatRVAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentClientChatBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (activity as? MainActivity)?.hideBottomNavigation(true)
+        init()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        (activity as? MainActivity)?.hideBottomNavigation(false)
+        _binding = null
+    }
+
+    private fun init() {
+        initRecyclerView()
+        initBackButton()
+        initMoreButton()
+        initBottomSheet()
+        // TODO: 추가할 초기화가 있다면 초기화
+    }
+
+    private fun initRecyclerView() {
+        // TODO : sender(현 사용자)의 id를 잘 전달해야함
+        clientChatRVAdapter = ClientChatRVAdapter(chatMessages, "1")
+        binding.commonChatLayout.rvChat.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = clientChatRVAdapter
+
+            // editText 가 눌리고 keyboard가 보이고 나서 recyclerview의 부분을 클릭하면 hide keyboard하기
+            setOnTouchListener { v, event ->
+                if (event.action == MotionEvent.ACTION_UP) {
+                    v.performClick()
+                    hideKeyboard()
+                }
+                false
+            }
+
+        }
+    }
+
+    private fun initBackButton() {
+        binding.toolbarLayout.toolbarWithTitleAndMoreBackButton.setOnClickListener {
+            hideKeyboard()
+            
+            // keyboard를 숨긴 후에 back되도록 (keyboard hide가 안된 것이 이전 화면에 영향을 줌)
+            it.postDelayed({
+                activity?.supportFragmentManager?.apply {
+                    beginTransaction().remove(this@ClientChatFragment).commit()
+                    popBackStack()
+                }  
+            }, 100) // 100초 뒤에 처리됨
+        }
+    }
+
+    private fun initMoreButton() {
+        binding.toolbarLayout.toolbarWithTitleAndMoreMoreButton.setOnClickListener {
+            val popup = PopupMenu(context, it)
+            popup.menuInflater.inflate(R.menu.top_more_menu, popup.menu)
+            // TODO: item click 리스너 구현 위치
+            popup.show()
+        }
+    }
+
+    private fun initBottomSheet() {
+        binding.clientFarmInfo.clientChatHistory.setOnClickListener {
+            val bottomSheetFragment = ChatBottomSheetFragment()
+            bottomSheetFragment.show(childFragmentManager, bottomSheetFragment.tag)
+        }
+    }
+
+    private fun hideKeyboard() {
+        val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        imm?.hideSoftInputFromWindow(view?.windowToken, 0)
+    }
+
+}

--- a/app/src/main/java/com/farm/farmus_application/ui/message/FarmerChatFragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/FarmerChatFragment.kt
@@ -1,0 +1,120 @@
+package com.farm.farmus_application.ui.message
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import android.widget.PopupMenu
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.farm.farmus_application.R
+import com.farm.farmus_application.databinding.FragmentFarmerChatBinding
+import com.farm.farmus_application.ui.MainActivity
+import com.farm.farmus_application.ui.message.adapter.FarmerChatRVAdapter
+
+
+class FarmerChatFragment : Fragment() {
+    private val TAG = "FarmerChatFragmentTAG"
+
+    private var _binding: FragmentFarmerChatBinding? = null
+    private val binding get() = _binding!!
+
+    // TODO : 임시 데이터. 사용 예시
+    private val chatMessages = ArrayList<ChatMessage>().apply {
+        // senderId 와 receivedId가 "0", "0"일 때는 날짜 업데이트를 하게 구현되어있음(rvAdapter와 함께 봐야함)
+        // 기능 구현시 그 부분을 고려해서 수정필요.
+        add(ChatMessage("0", "0", "2023년 01월 08일", "00:00"))
+
+        // 일반 대화 임시 데이터
+        add(ChatMessage("1", "2", "1이 2한테 보냄", "03:00"))
+        add(ChatMessage("2", "1", "2가 1한테 보냄", "03:01"))
+    }
+
+    private lateinit var farmerChatRVAdapter: FarmerChatRVAdapter
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentFarmerChatBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        (activity as? MainActivity)?.hideBottomNavigation(true)
+        init()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        (activity as? MainActivity)?.hideBottomNavigation(false)
+        _binding = null
+    }
+
+    private fun init() {
+        initRecyclerView()
+        initBackButton()
+        initMoreButton()
+        initBottomSheet()
+        // TODO: 추가할 초기화가 있다면 초기화
+    }
+
+    private fun initRecyclerView() {
+        // TODO : sender(현 사용자)의 id를 잘 전달해야함
+        farmerChatRVAdapter = FarmerChatRVAdapter(chatMessages, "1")
+        binding.commonChatLayout.rvChat.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = farmerChatRVAdapter
+
+            // editText 가 눌리고 keyboard가 보이고 나서 recyclerview의 부분을 클릭하면 hide keyboard하기
+            setOnTouchListener { v, event ->
+                if (event.action == MotionEvent.ACTION_UP) {
+                    v.performClick()
+                    hideKeyboard()
+                }
+                false
+            }
+        }
+    }
+
+    private fun initBackButton() {
+        binding.toolbarLayout.toolbarWithTitleAndMoreBackButton.setOnClickListener {
+            hideKeyboard()
+
+            // keyboard를 숨긴 후에 back되도록 (keyboard hide가 안된 것이 이전 화면에 영향을 줌)
+            it.postDelayed({
+                activity?.supportFragmentManager?.apply {
+                    beginTransaction().remove(this@FarmerChatFragment).commit()
+                    popBackStack()
+                }
+            }, 100) // 100초 뒤에 처리됨
+        }
+    }
+
+    private fun initBottomSheet() {
+        binding.farmerFarmInfo.farmerChatHistory.setOnClickListener {
+            val bottomSheetFragment = ChatBottomSheetFragment()
+            bottomSheetFragment.show(childFragmentManager, bottomSheetFragment.tag)
+        }
+    }
+
+    private fun initMoreButton() {
+        binding.toolbarLayout.toolbarWithTitleAndMoreMoreButton.setOnClickListener {
+            val popup = PopupMenu(context, it)
+            popup.menuInflater.inflate(R.menu.top_more_menu, popup.menu)
+            // TODO: item click 리스너 구현 위치
+            popup.show()
+        }
+    }
+
+    private fun hideKeyboard() {
+        val imm = activity?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        imm?.hideSoftInputFromWindow(view?.windowToken, 0)
+    }
+
+}

--- a/app/src/main/java/com/farm/farmus_application/ui/message/ShowBottomDialogInterface.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/ShowBottomDialogInterface.kt
@@ -1,8 +1,0 @@
-package com.farm.farmus_application.ui.message
-
-import android.view.View
-
-interface ShowBottomDialogInterface {
-
-    fun showBottomDialog(view : View)
-}

--- a/app/src/main/java/com/farm/farmus_application/ui/message/adapter/ChatTab1RVAdapter.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/adapter/ChatTab1RVAdapter.kt
@@ -4,6 +4,7 @@ package com.farm.farmus_application.ui.message.adapter
 import android.graphics.Paint
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -13,13 +14,25 @@ import com.farm.farmus_application.ui.message.*
 
 class ChatTab1RVAdapter : ListAdapter<RVTab1DataModel, ChatTab1RVAdapter.ViewHolder>(diffUtil) {
 
+    private var listener: OnItemClickListener? = null
+
+    interface OnItemClickListener {
+        fun itemClick()
+    }
+
+    fun setOnItemClick(listener: OnItemClickListener) {
+        this.listener = listener
+    }
+
     private lateinit var chatTab1Binding: RvChatTab1ItemBinding
+
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
     ): ViewHolder {
-        chatTab1Binding = RvChatTab1ItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        chatTab1Binding =
+            RvChatTab1ItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
         //텍스트 밑줄
         chatTab1Binding.rvChatHistory.paintFlags = Paint.UNDERLINE_TEXT_FLAG
 
@@ -30,22 +43,33 @@ class ChatTab1RVAdapter : ListAdapter<RVTab1DataModel, ChatTab1RVAdapter.ViewHol
         holder.bindItems(currentList[position])
     }
 
-    inner class ViewHolder(private val binding : RvChatTab1ItemBinding): RecyclerView.ViewHolder(binding.root){
+    inner class ViewHolder(private val binding: RvChatTab1ItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
 
-        fun bindItems(item: RVTab1DataModel){
+        fun bindItems(item: RVTab1DataModel) {
 
             binding.rvChatImg.setImageResource(item.farm_image)
             binding.rvChatName.text = item.farm_name
             binding.rvChatPeriodDay.text = item.farm_period
 
             binding.rvChatHistory.setOnClickListener {
+                val chatBottomSheetFragment = ChatBottomSheetFragment()
 
+                chatBottomSheetFragment.show(
+                    (binding.root.context as AppCompatActivity).supportFragmentManager,
+                    chatBottomSheetFragment.tag
+                )
+            }
+
+            // 필요시 root가 아니라 옆에 있는 > 으로 변경해서 처리
+            binding.root.setOnClickListener {
+                listener?.itemClick()
             }
         }
     }
 
-    companion object{
-        val diffUtil = object: DiffUtil.ItemCallback<RVTab1DataModel>(){
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<RVTab1DataModel>() {
             override fun areItemsTheSame(
                 oldItem: RVTab1DataModel,
                 newItem: RVTab1DataModel

--- a/app/src/main/java/com/farm/farmus_application/ui/message/adapter/ChatTab2RVAdapter.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/adapter/ChatTab2RVAdapter.kt
@@ -3,13 +3,25 @@ package com.farm.farmus_application.ui.message.adapter
 import android.graphics.Paint
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.farm.farmus_application.databinding.RvChatTab2ItemBinding
+import com.farm.farmus_application.ui.message.ChatBottomSheetFragment
 import com.farm.farmus_application.ui.message.RVTab2DataModel
 
-class ChatTab2RVAdapter() : ListAdapter<RVTab2DataModel, ChatTab2RVAdapter.ViewHolder>(diffUtil) {
+class ChatTab2RVAdapter : ListAdapter<RVTab2DataModel, ChatTab2RVAdapter.ViewHolder>(diffUtil) {
+
+    private var listener: OnItemClickListener? = null
+
+    interface OnItemClickListener {
+        fun itemClick()
+    }
+
+    fun setOnItemClick(listener: OnItemClickListener) {
+        this.listener = listener
+    }
 
     private lateinit var chatTab2Binding: RvChatTab2ItemBinding
 
@@ -36,11 +48,26 @@ class ChatTab2RVAdapter() : ListAdapter<RVTab2DataModel, ChatTab2RVAdapter.ViewH
             chatTab2Binding.rvChatImg.setImageResource(item.farm_image)
             chatTab2Binding.rvChatName.text = item.farm_name
             chatTab2Binding.rvChatPeriodDay.text = item.farm_period
+
+            chatTab2Binding.rvChatHistory.setOnClickListener {
+                val chatBottomSheetFragment = ChatBottomSheetFragment()
+
+                chatBottomSheetFragment.show(
+                    (chatTab2Binding.root.context as AppCompatActivity).supportFragmentManager,
+                    chatBottomSheetFragment.tag
+                )
+            }
+
+            // TODO : 필요시 root가 아니라 next_btn clcik 이벤트 등으로 변경해서 처리
+            chatTab2Binding.root.setOnClickListener {
+                listener?.itemClick()
+            }
+
         }
     }
 
-    companion object{
-        val diffUtil = object: DiffUtil.ItemCallback<RVTab2DataModel>(){
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<RVTab2DataModel>() {
             override fun areItemsTheSame(
                 oldItem: RVTab2DataModel,
                 newItem: RVTab2DataModel

--- a/app/src/main/java/com/farm/farmus_application/ui/message/adapter/ClientChatRVAdapter.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/adapter/ClientChatRVAdapter.kt
@@ -1,0 +1,91 @@
+package com.farm.farmus_application.ui.message.adapter
+
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.farm.farmus_application.databinding.ItemContainerDateBinding
+import com.farm.farmus_application.databinding.ItemContainerReceivedMessageBinding
+import com.farm.farmus_application.databinding.ItemContainerSentMessageBinding
+import com.farm.farmus_application.ui.message.ChatMessage
+
+
+// TODO : chatMessages List를 어떻게 받는 가에 따라서 파라미터로 처리가 안될 수도 있음
+// TODO : 구현시 나의 채팅 상대방 프로필 이미지를 끌어오는 방법이 필요함
+class ClientChatRVAdapter(private val chatMessages: List<ChatMessage>, private val senderId: String) :
+    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    enum class ViewType {
+        VIEW_TYPE_SENT, VIEW_TYPE_RECEIVED, VIEW_TYPE_DAY
+    }
+
+
+    override fun getItemViewType(position: Int): Int {
+        val chatMessage = chatMessages[position]
+        return when {
+            chatMessage.senderId == senderId -> {
+                ViewType.VIEW_TYPE_SENT.ordinal
+            }
+            chatMessage.senderId == "0" && chatMessage.receiverId == "0" -> {
+                ViewType.VIEW_TYPE_DAY.ordinal
+            }
+            else -> {
+                ViewType.VIEW_TYPE_RECEIVED.ordinal
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        return when (ViewType.values()[viewType]) {
+            ViewType.VIEW_TYPE_SENT -> {
+                val binding = ItemContainerSentMessageBinding.inflate(layoutInflater, parent, false)
+                SentMessageViewHolder(binding)
+            }
+            ViewType.VIEW_TYPE_RECEIVED -> {
+                val binding = ItemContainerReceivedMessageBinding.inflate(layoutInflater, parent, false)
+                ReceivedMessageViewHolder(binding)
+            }
+            ViewType.VIEW_TYPE_DAY -> {
+                val binding = ItemContainerDateBinding.inflate(layoutInflater, parent, false)
+                DayViewHolder(binding)
+            }
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return chatMessages.size
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val chatMessage = chatMessages[position]
+        when (ViewType.values()[getItemViewType(position)]) {
+            ViewType.VIEW_TYPE_SENT -> (holder as SentMessageViewHolder).setData(chatMessage)
+            ViewType.VIEW_TYPE_RECEIVED -> (holder as ReceivedMessageViewHolder).setData(chatMessage)
+            ViewType.VIEW_TYPE_DAY -> (holder as DayViewHolder).setData(chatMessage)
+        }
+    }
+
+    class SentMessageViewHolder(private val binding: ItemContainerSentMessageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun setData(chatMessage: ChatMessage) {
+            binding.textMessage.text = chatMessage.message
+            binding.textDateTime.text = chatMessage.dateTime
+        }
+    }
+
+    class ReceivedMessageViewHolder(private val binding: ItemContainerReceivedMessageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun setData(chatMessage: ChatMessage) {
+            binding.textMessage.text = chatMessage.message
+            binding.textDateTime.text = chatMessage.dateTime
+        }
+    }
+    class DayViewHolder(private val binding: ItemContainerDateBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun setData(chatMessage: ChatMessage) {
+            binding.tvDate.text = chatMessage.message
+        }
+    }
+}

--- a/app/src/main/java/com/farm/farmus_application/ui/message/adapter/FarmerChatRVAdapter.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/message/adapter/FarmerChatRVAdapter.kt
@@ -1,0 +1,103 @@
+package com.farm.farmus_application.ui.message.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.farm.farmus_application.databinding.ItemContainerDateBinding
+import com.farm.farmus_application.databinding.ItemContainerReceivedMessageBinding
+import com.farm.farmus_application.databinding.ItemContainerSentMessageBinding
+import com.farm.farmus_application.ui.message.ChatMessage
+
+class FarmerChatRVAdapter(
+    private val chatMessages: List<ChatMessage>,
+    private val senderId: String
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    enum class ViewType {
+        VIEW_TYPE_SENT, VIEW_TYPE_RECEIVED, VIEW_TYPE_DAY
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        val chatMessage = chatMessages[position]
+        return when {
+            chatMessage.senderId == senderId -> {
+                ClientChatRVAdapter.ViewType.VIEW_TYPE_SENT.ordinal
+            }
+
+            chatMessage.senderId == "0" && chatMessage.receiverId == "0" -> {
+                ClientChatRVAdapter.ViewType.VIEW_TYPE_DAY.ordinal
+            }
+
+            else -> {
+                ClientChatRVAdapter.ViewType.VIEW_TYPE_RECEIVED.ordinal
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        return when (ClientChatRVAdapter.ViewType.values()[viewType]) {
+            ClientChatRVAdapter.ViewType.VIEW_TYPE_SENT -> {
+                val binding = ItemContainerSentMessageBinding.inflate(layoutInflater, parent, false)
+                SentMessageViewHolder(binding)
+            }
+
+            ClientChatRVAdapter.ViewType.VIEW_TYPE_RECEIVED -> {
+                val binding =
+                    ItemContainerReceivedMessageBinding.inflate(layoutInflater, parent, false)
+                ReceivedMessageViewHolder(binding)
+            }
+
+            ClientChatRVAdapter.ViewType.VIEW_TYPE_DAY -> {
+                val binding = ItemContainerDateBinding.inflate(layoutInflater, parent, false)
+                DayViewHolder(binding)
+            }
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return chatMessages.size
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val chatMessage = chatMessages[position]
+        when (ClientChatRVAdapter.ViewType.values()[getItemViewType(position)]) {
+            ClientChatRVAdapter.ViewType.VIEW_TYPE_SENT -> (holder as SentMessageViewHolder).setData(
+                chatMessage
+            )
+
+            ClientChatRVAdapter.ViewType.VIEW_TYPE_RECEIVED -> (holder as ReceivedMessageViewHolder).setData(
+                chatMessage
+            )
+
+            ClientChatRVAdapter.ViewType.VIEW_TYPE_DAY -> (holder as DayViewHolder).setData(
+                chatMessage
+            )
+        }
+    }
+
+    class SentMessageViewHolder(private val binding: ItemContainerSentMessageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun setData(chatMessage: ChatMessage) {
+            binding.textMessage.text = chatMessage.message
+            binding.textDateTime.text = chatMessage.dateTime
+        }
+    }
+
+    class ReceivedMessageViewHolder(private val binding: ItemContainerReceivedMessageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun setData(chatMessage: ChatMessage) {
+            binding.textMessage.text = chatMessage.message
+            binding.textDateTime.text = chatMessage.dateTime
+        }
+    }
+
+    class DayViewHolder(private val binding: ItemContainerDateBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun setData(chatMessage: ChatMessage) {
+            binding.tvDate.text = chatMessage.message
+        }
+    }
+
+}

--- a/app/src/main/res/drawable/background_received_message.xml
+++ b/app/src/main/res/drawable/background_received_message.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <corners android:radius="10dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray_1" />
+</shape>

--- a/app/src/main/res/drawable/background_sent_message.xml
+++ b/app/src/main/res/drawable/background_sent_message.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/main" />
+    <corners android:radius="10dp" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray_1" />
+
+</shape>

--- a/app/src/main/res/drawable/more_vert_image.xml
+++ b/app/src/main/res/drawable/more_vert_image.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/text_second"
+        android:fillType="evenOdd"
+        android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z" />
+</vector>

--- a/app/src/main/res/drawable/round_background_color_border.xml
+++ b/app/src/main/res/drawable/round_background_color_border.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" >
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/gray_1">
+    </stroke>
+    <padding
+        android:left="5dp"
+        android:top="5dp"
+        android:right="5dp"
+        android:bottom="5dp">
+    </padding>
+    <corners
+        android:radius="11dp">
+    </corners>
+</shape>

--- a/app/src/main/res/layout/fragment_client_chat.xml
+++ b/app/src/main/res/layout/fragment_client_chat.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.message.ClientChatFragment">
+
+    <include
+        android:id="@+id/toolbar_layout"
+        layout="@layout/toolbar_with_title_and_more"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/farm_info_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_layout">
+
+        <include
+            android:id="@+id/client_farm_info"
+            layout="@layout/layout_client_chat_farm_info"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <include
+        android:id="@+id/common_chat_Layout"
+        layout="@layout/layout_chat_common"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/farm_info_layout" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_farmer_chat.xml
+++ b/app/src/main/res/layout/fragment_farmer_chat.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.message.FarmerChatFragment">
+
+    <include
+        android:id="@+id/toolbar_layout"
+        layout="@layout/toolbar_with_title_and_more"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/farm_info_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_layout">
+
+        <include
+            android:id="@+id/farmer_farm_info"
+            layout="@layout/layout_farmer_chat_farm_info"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <include
+        android:id="@+id/common_chat_Layout"
+        layout="@layout/layout_chat_common"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/farm_info_layout" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_container_date.xml
+++ b/app/src/main/res/layout/item_container_date.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/tv_date"
+        style="@style/Body2Reg"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="2023년 01월 08일"
+        android:textColor="@color/text_3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_container_received_message.xml
+++ b/app/src/main/res/layout/item_container_received_message.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="4sp">
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/card_view_profile_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="5dp"
+        android:layout_marginStart="5dp"
+        app:cardCornerRadius="40dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/profile_image"
+            android:layout_width="45dp"
+            android:layout_height="45dp"
+            android:background="@color/gray_2"
+            android:scaleType="centerCrop" />
+
+    </androidx.cardview.widget.CardView>
+
+    <TextView
+        android:id="@+id/textMessage"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:background="@drawable/background_received_message"
+        android:padding="12sp"
+        android:text="받은 메시지"
+        android:textColor="@color/text_3"
+        app:layout_constraintBottom_toBottomOf="@+id/card_view_profile_image"
+        app:layout_constraintStart_toEndOf="@+id/card_view_profile_image"
+        app:layout_constraintWidth_percent="0.7" />
+
+    <TextView
+        android:id="@+id/textDateTime"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="10sp"
+        android:text="17:43"
+        android:textColor="@color/text_3"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toBottomOf="@id/textMessage"
+        app:layout_constraintStart_toEndOf="@+id/textMessage" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_container_sent_message.xml
+++ b/app/src/main/res/layout/item_container_sent_message.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="4sp">
+
+    <TextView
+        android:id="@+id/textMessage"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="10dp"
+        android:background="@drawable/background_sent_message"
+        android:padding="12sp"
+        android:text="보내는 메시지"
+        android:textColor="@color/white"
+        android:textSize="13sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.7" />
+
+    <TextView
+        android:id="@+id/textDateTime"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="10sp"
+        android:text="17:16"
+        android:textColor="@color/text_3"
+        android:textSize="13sp"
+        app:layout_constraintBottom_toBottomOf="@id/textMessage"
+        app:layout_constraintEnd_toStartOf="@+id/textMessage" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_chat_common.xml
+++ b/app/src/main/res/layout/layout_chat_common.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- 채팅 대화 내용 부분-->
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_chat"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#F5F5F5"
+        android:clipToPadding="false"
+        android:orientation="vertical"
+        android:overScrollMode="never"
+        android:padding="5sp"
+        app:layout_constraintBottom_toTopOf="@+id/layout_send"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+    <!--
+        대화 내용 업로드 x 일 때, Progress bar를 이용하기도 하는 것 같다..
+    -->
+
+
+    <!-- 채팅 내용 입력 부분 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_send"
+        android:layout_width="match_parent"
+        android:layout_height="70dp"
+        android:background="@color/white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent">
+
+        <ImageButton
+            android:id="@+id/btn_plus"
+            android:layout_width="50dp"
+            android:layout_height="match_parent"
+            android:layout_marginVertical="10dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginRight="5dp"
+            android:background="@color/white"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintWidth_percent="0.3"
+            app:srcCompat="@drawable/plus_line_vector_image" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginVertical="10dp"
+            android:layout_marginLeft="5dp"
+            android:layout_marginRight="5dp"
+            android:background="@drawable/round_background_color_border"
+            android:orientation="horizontal"
+            app:layout_constraintLeft_toRightOf="@+id/btn_plus"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintWidth_percent="0.7">
+
+            <EditText
+                android:id="@+id/edittext_send_msg"
+                android:layout_width="280dp"
+                android:layout_height="match_parent"
+                android:layout_marginRight="5dp"
+                android:background="@null"
+                android:hint="내용 입력"
+                android:paddingLeft="10dp"
+                android:textColor="@color/text_2"
+                android:textSize="15sp" />
+
+            <ImageButton
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:background="@color/white"
+                app:srcCompat="@drawable/send_vector_image" />
+
+        </LinearLayout>
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_client_chat_farm_info.xml
+++ b/app/src/main/res/layout/layout_client_chat_farm_info.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/client_chat_img_card_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:cardCornerRadius="7dp"
+            android:layout_marginTop="23dp"
+            android:layout_marginStart="15dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <ImageView
+                android:id="@+id/client_chat_img"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:src="@drawable/farm_image_example"
+                android:scaleType="centerCrop"
+                />
+        </androidx.cardview.widget.CardView>
+
+
+
+        <TextView
+            android:id="@+id/client_chat_farm_name"
+            style="@style/Body1Bold"
+            android:textColor="@color/text_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="@id/client_chat_img_card_view"
+            app:layout_constraintStart_toEndOf="@id/client_chat_img_card_view"
+            android:layout_marginTop="5dp"
+            android:layout_marginStart="10dp"
+            android:text="서울 유일 농장"/>
+
+        <TextView
+            android:id="@+id/client_chat_period"
+            style="@style/Body3Med"
+            android:textColor="@color/text_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/client_chat_farm_name"
+            app:layout_constraintStart_toEndOf="@id/client_chat_img_card_view"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="6dp"
+            android:text="희망 분양기간 "/>
+
+        <TextView
+            android:id="@+id/client_chat_period_day"
+            style="@style/Body3Med"
+            android:textColor="@color/text_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toEndOf="@id/client_chat_period"
+            app:layout_constraintTop_toTopOf="@id/client_chat_period"
+            android:text="2022.05.12. ~ 2022.12.07."/>
+
+        <ImageButton
+            android:id="@+id/client_chat_btn_next"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:background="@drawable/next_black_vector_image"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/client_chat_farm_name"
+            android:layout_marginEnd="16dp"/>
+
+        <TextView
+            android:id="@+id/client_chat_history"
+            style="@style/Body3Reg"
+            android:textColor="@color/text_3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/client_chat_period"
+            app:layout_constraintStart_toEndOf="@id/client_chat_img_card_view"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="6dp"
+            android:text="분양 신청 내역"/>
+
+        <TextView
+            android:id="@+id/client_chat_state"
+            style="@style/Body3Med"
+            android:textColor="@color/text_3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="4dp"
+            android:text="신청대기"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/client_chat_period_day"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="18dp"
+            android:layout_marginBottom="17dp"/>
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/gray_2"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/layout_farmer_chat_farm_info.xml
+++ b/app/src/main/res/layout/layout_farmer_chat_farm_info.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.cardview.widget.CardView
+            android:id="@+id/farmer_chat_img_card_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:layout_marginTop="23dp"
+            app:cardCornerRadius="7dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/farmer_chat_img"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:scaleType="centerCrop"
+                android:src="@drawable/farm_image_example" />
+        </androidx.cardview.widget.CardView>
+
+        <TextView
+            android:id="@+id/farmer_chat_farm_name"
+            style="@style/Body1Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="5dp"
+            android:text="서울 유일 농장"
+            android:textColor="@color/text_1"
+            app:layout_constraintStart_toEndOf="@id/farmer_chat_img_card_view"
+            app:layout_constraintTop_toTopOf="@id/farmer_chat_img_card_view" />
+
+        <TextView
+            android:id="@+id/farmer_chat_period"
+            style="@style/Body3Med"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="6dp"
+            android:text="희망 분양기간 "
+            android:textColor="@color/text_2"
+            app:layout_constraintStart_toEndOf="@id/farmer_chat_img_card_view"
+            app:layout_constraintTop_toBottomOf="@id/farmer_chat_farm_name" />
+
+        <TextView
+            android:id="@+id/farmer_chat_period_day"
+            style="@style/Body3Med"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="2022.05.12. ~ 2022.12.07."
+            android:textColor="@color/text_2"
+            app:layout_constraintStart_toEndOf="@id/farmer_chat_period"
+            app:layout_constraintTop_toTopOf="@id/farmer_chat_period" />
+
+        <ImageButton
+            android:id="@+id/farmer_chat_btn_next"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginEnd="16dp"
+            android:background="@drawable/next_black_vector_image"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/farmer_chat_farm_name" />
+
+        <TextView
+            android:id="@+id/farmer_chat_history"
+            style="@style/Body3Reg"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="6dp"
+            android:text="분양 신청 내역"
+            android:textColor="@color/text_3"
+            app:layout_constraintStart_toEndOf="@id/farmer_chat_img_card_view"
+            app:layout_constraintTop_toBottomOf="@id/farmer_chat_period" />
+
+        <TextView
+            android:id="@+id/farmer_chat_use_textview"
+            style="@style/Body3Med"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="24dp"
+            android:layout_marginBottom="23dp"
+            android:text="승인됨"
+            android:textColor="@color/main"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/farmer_chat_history" />
+
+
+        <TextView
+            android:id="@+id/farmer_chat_btn_cancel"
+            style="@style/Body3Med"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="13dp"
+            android:background="@drawable/corner_radius_rv_rec_item_box"
+            android:backgroundTint="@color/gray_3"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="8dp"
+            android:text="거절"
+            android:textColor="@color/text_3"
+            app:layout_constraintBottom_toBottomOf="@id/farmer_chat_btn_approve"
+            app:layout_constraintEnd_toStartOf="@id/farmer_chat_btn_approve" />
+
+        <TextView
+            android:id="@+id/farmer_chat_btn_approve"
+            style="@style/Body3Med"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="24dp"
+            android:layout_marginBottom="23dp"
+            android:background="@drawable/corner_radius_rv_rec_item_box"
+            android:backgroundTint="@color/gray_3"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="8dp"
+            android:text="승인"
+            android:textColor="@color/text_3"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/farmer_chat_history" />
+
+        <ImageView
+            android:id="@+id/imageView4"
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/gray_2"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/toolbar_with_title_and_more.xml
+++ b/app/src/main/res/layout/toolbar_with_title_and_more.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/toolbar_with_title_and_more"
+    android:layout_width="match_parent"
+    android:layout_height="56dp"
+    android:background="@color/white"
+    app:contentInsetStart="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ImageButton
+            android:id="@+id/toolbar_with_title_and_more_back_button"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@color/white"
+            android:contentDescription="@string/previous"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.01"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/back_vector_image"
+            tools:ignore="TouchTargetSizeCheck" />
+
+        <TextView
+            android:id="@+id/toolbar_main_title_text"
+            style="@style/Body1Bold"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/example_text"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.5" />
+
+        <ImageButton
+            android:id="@+id/toolbar_with_title_and_more_more_button"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_marginRight="10dp"
+            android:background="@color/white"
+            android:contentDescription="더보기"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.01"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/more_vert_image"
+            tools:ignore="TouchTargetSizeCheck" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/menu/top_more_menu.xml
+++ b/app/src/main/res/menu/top_more_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/off_alert"
+        android:title="알람 끄기"/>
+    <item
+        android:id="@+id/leave_room"
+        android:title="방 나가기"/>
+</menu>


### PR DESCRIPTION
## 구현한 기능
Chatting Tab 부분의 전반적인 View와 이동로직 등 + 임시 아이템 넣어놓기

## 개선할 점
<ul>
    <li> chatting을 위해 senderId(로그인한 사용자)와 recieverId(채팅을 주고받는 사용자)를 표시해서 데이터를 담아놓았는데, 기능 구현에 따라 전반적인 수정이 있을 수도 있음.</li>
 <li> chatting을 위해 editText(채팅 입력란) 클릭 후, 키보드가 보이는 상태에서 뒤로가기 버튼 클릭시 이전 View의 RecyclerView 부분이 작아지는 문제 발생 → 임시로 키보드를 먼저 닫고 나서 뒤로 넘어가기를 진행시켰으나 좋은 방법같지는 않습니다.</li>
  <li>이 외에도 여러 기능 구현에 따라 수정과 함께 나머지 작업 진행이 예상됨.</li>
</ul>