### PR TITLE
농장주(farmer)가 농장 이용 불가 기간 등록 및 삭제

### DIFF
--- a/app/src/main/java/com/farm/farmus_application/di/AppModule.kt
+++ b/app/src/main/java/com/farm/farmus_application/di/AppModule.kt
@@ -64,47 +64,23 @@ object AppModule {
         return retrofit.create(UserApiClient::class.java)
     }
 
-    // Repository를 Module로 만들어줘야 하는 이유가 없는거같아서 일단 주석처리
-//    @Provides
-//    @Singleton
-//    fun provideUserRepository(userApiClient: UserApiClient) : UserRepository {
-//        return UserRepository(userApiClient)
-//    }
 
     @Provides
     @Singleton
     fun provideFarmApiClient(retrofit: Retrofit) : FarmApiClient {
         return retrofit.create(FarmApiClient::class.java)
     }
-//
-//    @Provides
-//    @Singleton
-//    fun provideFarmRepository(farmApiClient: FarmApiClient) : FarmRepository {
-//        return FarmRepository(farmApiClient)
-//    }
-//
+
     @Provides
     @Singleton
     fun provideMyPageApiClient(retrofit: Retrofit) : MyPageApiClient {
         return retrofit.create(MyPageApiClient::class.java)
     }
-//
-//    @Provides
-//    @Singleton
-//    fun provideMyPageRepository(myPageApiClient: MyPageApiClient) : MyPageRepository {
-//        return MyPageRepository(myPageApiClient)
-//    }
-//
+
     @Provides
     @Singleton
     fun provideReserveApiClient(retrofit: Retrofit) : ReserveApiClient {
         return retrofit.create(ReserveApiClient::class.java)
     }
-//
-//    @Provides
-//    @Singleton
-//    fun provideReserveRepository(reserveApiClient: ReserveApiClient) : ReserveRepository {
-//        return ReserveRepository(reserveApiClient)
-//    }
 
 }

--- a/app/src/main/java/com/farm/farmus_application/di/AppModule.kt
+++ b/app/src/main/java/com/farm/farmus_application/di/AppModule.kt
@@ -1,6 +1,5 @@
 package com.farm.farmus_application.di
 
-import com.example.farmus_application.network.*
 import com.farm.farmus_application.network.FarmApiClient
 import com.farm.farmus_application.network.MyPageApiClient
 import com.farm.farmus_application.network.ReserveApiClient

--- a/app/src/main/java/com/farm/farmus_application/di/DataSourceModule.kt
+++ b/app/src/main/java/com/farm/farmus_application/di/DataSourceModule.kt
@@ -1,0 +1,16 @@
+package com.farm.farmus_application.di
+
+import com.farm.farmus_application.repository.farm.FarmDataSourceInterface
+import com.farm.farmus_application.repository.farm.FarmRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class DataSourceModule {
+
+    @Binds
+    abstract fun bindFarmDataSource(farmDataSourceImpl: FarmRepository): FarmDataSourceInterface
+}

--- a/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/DeleteDateRes.kt
+++ b/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/DeleteDateRes.kt
@@ -1,0 +1,10 @@
+package com.farm.farmus_application.model.farm.unavailableDate
+
+import com.google.gson.annotations.SerializedName
+
+data class DeleteDateRes(
+    @SerializedName("isSuccess") val isSuccess : Boolean,
+    @SerializedName("code") val code : Int,
+    @SerializedName("message") val message : String,
+    @SerializedName("result") val result : FarmDataID
+)

--- a/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/FarmDateID.kt
+++ b/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/FarmDateID.kt
@@ -1,0 +1,8 @@
+package com.farm.farmus_application.model.farm.unavailableDate
+
+import com.google.gson.annotations.SerializedName
+
+data class FarmDataID(
+    @SerializedName("farmDateID") val farmDateID : Int,
+)
+

--- a/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/RetrieveDateRes.kt
+++ b/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/RetrieveDateRes.kt
@@ -31,4 +31,17 @@ data class UnavailableDateInfo(
     fun getFormattedEndDate(): String {
         return formatDate(UnavailableEndDate)
     }
+
+    private fun parseDate(dateString: String): Date? {
+        val parser = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        return parser.parse(dateString)
+    }
+
+    fun getStartDate(): Date? {
+        return parseDate(UnavailableStartDate)
+    }
+
+    fun getEndDate(): Date? {
+        return parseDate(UnavailableEndDate)
+    }
 }

--- a/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/RetrieveDateRes.kt
+++ b/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/RetrieveDateRes.kt
@@ -1,0 +1,34 @@
+package com.farm.farmus_application.model.farm.unavailableDate
+
+import com.google.gson.annotations.SerializedName
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+data class RetrieveDateRes(
+    @SerializedName("isSuccess") val isSuccess : Boolean,
+    @SerializedName("code") val code : Int,
+    @SerializedName("message") val message : String,
+    @SerializedName("result") val result : List<UnavailableDateInfo>
+)
+
+data class UnavailableDateInfo(
+    @SerializedName("FarmDateID") val FarmDateID : Int,
+    @SerializedName("UnavailableStartDate") val UnavailableStartDate : String,
+    @SerializedName("UnavailableEndDate") val UnavailableEndDate : String
+){
+    private fun formatDate(dateString: String): String {
+        val parser = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+        val date = parser.parse(dateString)
+        val formatter = SimpleDateFormat("yyyy.MM.dd", Locale.getDefault())
+        return formatter.format(date ?: Date())
+    }
+
+    fun getFormattedStartDate(): String {
+        return formatDate(UnavailableStartDate)
+    }
+
+    fun getFormattedEndDate(): String {
+        return formatDate(UnavailableEndDate)
+    }
+}

--- a/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/UnavailableDateAdditionReq.kt
+++ b/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/UnavailableDateAdditionReq.kt
@@ -1,0 +1,10 @@
+package com.farm.farmus_application.model.farm.unavailableDate
+
+import com.google.gson.annotations.SerializedName
+
+// 농장주가 농장 이용불가 기간 추가 하는 API의 Req
+data class UnavailableDateAdditionReq(
+    @SerializedName("farmID") val farmID : Int,
+    @SerializedName("unavailableStartDate") val unavailableStartDate : String,
+    @SerializedName("unavailableEndDate") val unavailableEndDate : String
+)

--- a/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/UnavailaleDateAdditionRes.kt
+++ b/app/src/main/java/com/farm/farmus_application/model/farm/unavailableDate/UnavailaleDateAdditionRes.kt
@@ -1,0 +1,11 @@
+package com.farm.farmus_application.model.farm.unavailableDate
+
+import com.google.gson.annotations.SerializedName
+
+// 농장주가 농장 이용불가 기간 추가 하는 API의 Res
+data class UnavailaleDateAdditionRes(
+    @SerializedName("isSuccess") val isSuccess : Boolean,
+    @SerializedName("code") val code : String,
+    @SerializedName("message") val message : String,
+    @SerializedName("result") val result : FarmDataID // List형태로 날라오는 건지 궁금...
+)

--- a/app/src/main/java/com/farm/farmus_application/network/FarmApiClient.kt
+++ b/app/src/main/java/com/farm/farmus_application/network/FarmApiClient.kt
@@ -8,6 +8,10 @@ import com.farm.farmus_application.model.farm.phone.PhoneNumberRes
 import com.farm.farmus_application.model.farm.postings.PostingsRes
 import com.farm.farmus_application.model.farm.register.RegisterRes
 import com.farm.farmus_application.model.farm.search.SearchedRes
+import com.farm.farmus_application.model.farm.unavailableDate.DeleteDateRes
+import com.farm.farmus_application.model.farm.unavailableDate.RetrieveDateRes
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailableDateAdditionReq
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailaleDateAdditionRes
 import com.farm.farmus_application.model.favorite.FavoriteFarmRes
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -74,5 +78,14 @@ interface FarmApiClient {
 
     @GET("/farm/myfarm")
     suspend fun getMyFarm():Response<MyFarmRes>
+
+    @POST("/farm/unavailableDate")
+    suspend fun postUnavailableDate(@Body params : UnavailableDateAdditionReq) : Response<UnavailaleDateAdditionRes>
+
+    @PUT("/farm/unavailableDate/delete/{farmDateID}")
+    suspend fun putDeleteUnavailableDate(@Path("farmDateID")farmDateID : Int) : Response<DeleteDateRes>
+
+    @GET("/farm/unavailableDate/{farmId}")
+    suspend fun getUnavailableDate(@Path("farmId")farmId : Int) : Response<RetrieveDateRes>
 
 }

--- a/app/src/main/java/com/farm/farmus_application/repository/farm/FarmDataSourceInterface.kt
+++ b/app/src/main/java/com/farm/farmus_application/repository/farm/FarmDataSourceInterface.kt
@@ -8,6 +8,10 @@ import com.farm.farmus_application.model.farm.phone.PhoneNumberRes
 import com.farm.farmus_application.model.farm.postings.PostingsRes
 import com.farm.farmus_application.model.farm.register.RegisterRes
 import com.farm.farmus_application.model.farm.search.SearchedRes
+import com.farm.farmus_application.model.farm.unavailableDate.DeleteDateRes
+import com.farm.farmus_application.model.farm.unavailableDate.RetrieveDateRes
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailableDateAdditionReq
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailaleDateAdditionRes
 import com.farm.farmus_application.model.favorite.FavoriteFarmRes
 import retrofit2.Response
 import java.io.File
@@ -57,5 +61,10 @@ interface FarmDataSourceInterface {
     suspend fun getMyFarm(): Response<MyFarmRes>
   
     suspend fun getFavoriteFarmList(email: String): Response<FavoriteFarmRes>
+
+    suspend fun postUnavailableDate(params : UnavailableDateAdditionReq) : Response<UnavailaleDateAdditionRes>
+
+    suspend fun putDeleteUnavailableDate(farmDateID : Int) : Response<DeleteDateRes>
+    suspend fun getUnavailableDate(farmId : Int) : Response<RetrieveDateRes>
 
 }

--- a/app/src/main/java/com/farm/farmus_application/repository/farm/FarmRepository.kt
+++ b/app/src/main/java/com/farm/farmus_application/repository/farm/FarmRepository.kt
@@ -1,6 +1,5 @@
 package com.farm.farmus_application.repository.farm
 
-import android.util.Log
 import com.farm.farmus_application.model.farm.detail.DetailRes
 import com.farm.farmus_application.model.farm.detail.DetailResult
 import com.farm.farmus_application.model.farm.editinfo.EditinfoRes
@@ -17,7 +16,6 @@ import com.farm.farmus_application.model.favorite.FavoriteFarmRes
 import com.farm.farmus_application.network.FarmApiClient
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
-import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import retrofit2.Response

--- a/app/src/main/java/com/farm/farmus_application/repository/farm/FarmRepository.kt
+++ b/app/src/main/java/com/farm/farmus_application/repository/farm/FarmRepository.kt
@@ -9,7 +9,10 @@ import com.farm.farmus_application.model.farm.myfarm.MyFarmRes
 import com.farm.farmus_application.model.farm.phone.PhoneNumberRes
 import com.farm.farmus_application.model.farm.postings.PostingsRes
 import com.farm.farmus_application.model.farm.register.RegisterRes
-import com.farm.farmus_application.model.farm.search.SearchedRes
+import com.farm.farmus_application.model.farm.search.SearchedRes import com.farm.farmus_application.model.farm.unavailableDate.DeleteDateRes
+import com.farm.farmus_application.model.farm.unavailableDate.RetrieveDateRes
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailableDateAdditionReq
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailaleDateAdditionRes
 import com.farm.farmus_application.model.favorite.FavoriteFarmRes
 import com.farm.farmus_application.network.FarmApiClient
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -178,5 +181,15 @@ class FarmRepository @Inject constructor(
         return farmDetail
     }
     // -----------------------------------------
+    override suspend fun postUnavailableDate(params : UnavailableDateAdditionReq) : Response<UnavailaleDateAdditionRes>{
+        return farmApiClient.postUnavailableDate(params)
+    }
+
+    override suspend fun putDeleteUnavailableDate(farmDateID : Int) : Response<DeleteDateRes>{
+        return farmApiClient.putDeleteUnavailableDate(farmDateID)
+    }
+    override suspend fun getUnavailableDate(farmId : Int) : Response<RetrieveDateRes>{
+        return farmApiClient.getUnavailableDate(farmId)
+    }
     
 }

--- a/app/src/main/java/com/farm/farmus_application/ui/farm/ManagementCalendarFragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/farm/ManagementCalendarFragment.kt
@@ -101,7 +101,6 @@ class ManagementCalendarFragment : Fragment(), OnDeleteClickListener {
             }
             settingCalendarLastText(dates[dates.size - 1])
             activateAddButton(true)
-
         }
 
         // '추가' 버튼 클릭 이벤트
@@ -109,11 +108,17 @@ class ManagementCalendarFragment : Fragment(), OnDeleteClickListener {
             if (binding.managementCalendarAdd.isSelected) {
                 val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
 
-                val calendar = Calendar.getInstance()
-                calendar.set(firstSelectedDay.year, firstSelectedDay.month - 1, firstSelectedDay.day) // CalendarDay의 month는 1을 빼야 합니다 (0-11 범위)
-                val unavailableStartDate = dateFormat.format(calendar.time)
-                calendar.set(lastSelectedDay.year, lastSelectedDay.month - 1, lastSelectedDay.day)
-                val unavailableEndDate = dateFormat.format(calendar.time)
+                // CalendarDay를 Calendar로 변환
+                val startCalendar = Calendar.getInstance().apply {
+                    set(firstSelectedDay.year, firstSelectedDay.month - 1, firstSelectedDay.day)
+                }
+                val endCalendar = Calendar.getInstance().apply {
+                    set(lastSelectedDay.year, lastSelectedDay.month - 1, lastSelectedDay.day)
+                }
+
+                // 포맷된 날짜 문자열 생성
+                val unavailableStartDate = dateFormat.format(startCalendar.time)
+                val unavailableEndDate = dateFormat.format(endCalendar.time)
 
                 managementCalendarViewModel.addUnavailableDate(
                     farmId,

--- a/app/src/main/java/com/farm/farmus_application/ui/farm/ManagementCalendarFragment.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/farm/ManagementCalendarFragment.kt
@@ -1,5 +1,6 @@
 package com.farm.farmus_application.ui.farm
 
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -9,15 +10,22 @@ import android.widget.Toast
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.farm.farmus_application.R
 import com.farm.farmus_application.databinding.FragmentManagementCalendarBinding
 import com.farm.farmus_application.model.reserve.unbookable.UnBookableResult
+import com.farm.farmus_application.ui.farm.adapter.ManagementRVAdapter
+import com.farm.farmus_application.ui.farm.adapter.OnDeleteClickListener
 import com.farm.farmus_application.viewmodel.calendar.CalendarViewModel
+import com.farm.farmus_application.viewmodel.farm.ManagementCalendarViewModel
 import com.prolificinteractive.materialcalendarview.CalendarDay
 import dagger.hilt.android.AndroidEntryPoint
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
 
 @AndroidEntryPoint
-class ManagementCalendarFragment: Fragment() {
+class ManagementCalendarFragment : Fragment(), OnDeleteClickListener {
 
     private lateinit var binding: FragmentManagementCalendarBinding
     private lateinit var firstSelectedDay: CalendarDay
@@ -25,13 +33,21 @@ class ManagementCalendarFragment: Fragment() {
     private var farmId = 0
     private var unBookDayList: List<UnBookableResult> = listOf()
     private val calendarViewModel: CalendarViewModel by viewModels()
+    private val managementCalendarViewModel: ManagementCalendarViewModel by viewModels()
+    private val managementRVAdapter = ManagementRVAdapter(this)
+
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_management_calendar, container, false)
+        binding = DataBindingUtil.inflate(
+            inflater,
+            R.layout.fragment_management_calendar,
+            container,
+            false
+        )
         farmId = arguments?.getInt("farmId") ?: 0
         return binding.root
     }
@@ -41,6 +57,7 @@ class ManagementCalendarFragment: Fragment() {
 
         initView()
 
+        // 뒤로 가기 버튼
         binding.managementCalendarBack.setOnClickListener {
             activity?.supportFragmentManager?.apply {
                 beginTransaction().remove(this@ManagementCalendarFragment).commit()
@@ -53,41 +70,99 @@ class ManagementCalendarFragment: Fragment() {
                 result.result?.let {
                     binding.managementCalendar.addDecorator(UnBookableDayDecorator(it))
                     unBookDayList = it
-                    Log.e("unBookDayList","$unBookDayList")
+                    Log.e("unBookDayList", "$unBookDayList")
                 }
             } else {
                 Toast.makeText(requireContext(), result.message, Toast.LENGTH_SHORT).show()
             }
         }
 
-        binding.managementCalendar.setOnDateChangedListener { widget, date, selected ->
+        binding.managementCalendar.setOnDateChangedListener { widget, date, _ ->
             widget.apply {
                 removeDecorators()
                 addDecorator(SelectedDecorator(date))
-                addDecorators(TodayDecorator(requireContext()), BeforeDayDecorator(),SelectedDecorator(date))
+                addDecorators(
+                    TodayDecorator(requireContext()),
+                    BeforeDayDecorator(),
+                    SelectedDecorator(date)
+                )
             }
             settingCalendarStartText(date)
-            switchDateFocus(true)
+            activateAddButton(false)
         }
 
         binding.managementCalendar.setOnRangeSelectedListener { widget, dates ->
             val dayList = mutableListOf<CalendarDay>().apply {
                 addAll(dates)
                 removeAt(0)
-                removeAt(this.size -1)
+                removeAt(this.size - 1)
             }
             if (firstSelectedDay != dates[0]) {
                 widget.addDecorator(SelectedDecorator(dates[0]))
                 settingCalendarStartText(dates[0])
             } else {
-                widget.addDecorator(SelectedDecorator(dates[dates.size -1]))
+                widget.addDecorator(SelectedDecorator(dates[dates.size - 1]))
             }
             if (dayList.size != 0) {
                 widget.addDecorator(RangeDayDecorator(dayList, requireContext()))
             }
-            settingCalendarLastText(dates[dates.size-1])
-            switchDateFocus(false)
+            settingCalendarLastText(dates[dates.size - 1])
+            activateAddButton(true)
+
         }
+
+        // '추가' 버튼 클릭 이벤트
+        binding.managementCalendarAdd.setOnClickListener {
+            if (binding.managementCalendarAdd.isSelected) {
+                val dateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+                val calendar = Calendar.getInstance()
+                calendar.set(
+                    firstSelectedDay.year,
+                    firstSelectedDay.month - 1,
+                    firstSelectedDay.day
+                ) // CalendarDay의 month는 1을 빼야 합니다 (0-11 범위)
+                val unavailableStartDate = dateFormat.format(calendar.time)
+
+                calendar.set(lastSelectedDay.year, lastSelectedDay.month - 1, lastSelectedDay.day)
+                val unavailableEndDate = dateFormat.format(calendar.time)
+
+                managementCalendarViewModel.addUnavailableDate(
+                    farmId,
+                    unavailableStartDate,
+                    unavailableEndDate
+                )
+            }
+        }
+
+        // 이용 불가 기간 추가 버튼 클릭 후 결과 관찰
+        managementCalendarViewModel.isSuccessAddDate.observe(viewLifecycleOwner) {
+            if (it) {
+                managementCalendarViewModel.addUnavailableDate(
+                    farmId,
+                    firstSelectedDay.toString(),
+                    lastSelectedDay.toString()
+                )
+            }
+        }
+
+        managementCalendarViewModel.isSuccessDeleteDate.observe(viewLifecycleOwner) {
+            if (it) {
+                Toast.makeText(context, "삭제되었습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+
+        // 이용 불가 기간 목록 전체 확인 -> 리사이클러 뷰로 아이템 넣기
+        managementCalendarViewModel.unavailableDateInfoList.observe(viewLifecycleOwner) {
+            managementRVAdapter.submitList(it)
+        }
+
+        managementCalendarViewModel.errorMessage.observe(viewLifecycleOwner) { errorMessage ->
+            Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+        }
+
+
     }
 
     private fun initView() {
@@ -102,35 +177,50 @@ class ManagementCalendarFragment: Fragment() {
             setLeftArrow(R.drawable.calendar_back_button_vector)
             setRightArrow(R.drawable.calendar_forward_button_vector)
         }
+
+        binding.dateRecyclerView.layoutManager = LinearLayoutManager(context)
+        binding.dateRecyclerView.adapter = managementRVAdapter;
+
+        managementCalendarViewModel.getUnavailableDateList(farmId)
     }
 
     private fun settingCalendarStartText(date: CalendarDay) {
         binding.apply {
             calendarStartDayYear.text = date.year.toString()
-            calendarStartDayMonth.text = String.format("%02d",date.month)
+            calendarStartDayMonth.text = String.format("%02d", date.month)
             calendarStartDayDate.text = date.day.toString()
         }
         firstSelectedDay = date
     }
+
     private fun settingCalendarLastText(date: CalendarDay) {
         binding.apply {
             calendarLastDayYear.text = date.year.toString()
-            calendarLastDayMonth.text = String.format("%02d",date.month)
+            calendarLastDayMonth.text = String.format("%02d", date.month)
             calendarLastDayDate.text = date.day.toString()
         }
         lastSelectedDay = date
     }
-    private fun switchDateFocus(switch: Boolean) {
+
+    private fun activateAddButton(switch: Boolean) {
         if (switch) {
             binding.apply {
                 startDayConstraint.isSelected = true
                 lastDayConstraint.isSelected = false
+                managementCalendarAdd.setTextColor(Color.GREEN)
+                managementCalendarAdd.isSelected = true
             }
         } else {
             binding.apply {
                 startDayConstraint.isSelected = false
                 lastDayConstraint.isSelected = true
+                managementCalendarAdd.setTextColor(Color.GRAY)
+                managementCalendarAdd.isSelected = false
             }
         }
+    }
+
+    override fun onDeleteClick(farmDateID: Int) {
+        managementCalendarViewModel.deleteUnavailableDate(farmDateID, farmId)
     }
 }

--- a/app/src/main/java/com/farm/farmus_application/ui/farm/UnavailableDatesDecorator.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/farm/UnavailableDatesDecorator.kt
@@ -1,0 +1,19 @@
+package com.farm.farmus_application.ui.farm
+
+import android.graphics.Color
+import android.text.style.BackgroundColorSpan
+import com.prolificinteractive.materialcalendarview.CalendarDay
+import com.prolificinteractive.materialcalendarview.DayViewDecorator
+import com.prolificinteractive.materialcalendarview.DayViewFacade
+
+class UnavailableDatesDecorator(private val dates: List<CalendarDay>) : DayViewDecorator {
+    override fun shouldDecorate(day: CalendarDay?): Boolean {
+        return dates.contains(day)
+    }
+
+    override fun decorate(view: DayViewFacade) {
+        view.addSpan(object : BackgroundColorSpan(Color.LTGRAY) {})
+        view.setDaysDisabled(true)
+    }
+
+}

--- a/app/src/main/java/com/farm/farmus_application/ui/farm/adapter/ManagementRVAdapter.kt
+++ b/app/src/main/java/com/farm/farmus_application/ui/farm/adapter/ManagementRVAdapter.kt
@@ -8,14 +8,28 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.farm.farmus_application.R
 import com.farm.farmus_application.databinding.ItemManagementCalnedarBinding
-import com.farm.farmus_application.model.reserve.unbookable.UnBookableResult
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailableDateInfo
 
-class ManagementRVAdapter: ListAdapter<UnBookableResult, ManagementRVAdapter.ManagementViewHolder>(diffUtil) {
+interface OnDeleteClickListener {
+    fun onDeleteClick(farmDateID: Int)
+}
+
+class ManagementRVAdapter(
+    private val onDeleteClickListener: OnDeleteClickListener
+) :
+    ListAdapter<UnavailableDateInfo, ManagementRVAdapter.ManagementViewHolder>(diffUtil) {
 
     private lateinit var binding: ItemManagementCalnedarBinding
 
+
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ManagementViewHolder {
-        binding = DataBindingUtil.inflate(LayoutInflater.from(parent.context), R.layout.item_management_calnedar, parent, false)
+        binding = DataBindingUtil.inflate(
+            LayoutInflater.from(parent.context),
+            R.layout.item_management_calnedar,
+            parent,
+            false
+        )
         return ManagementViewHolder(binding)
     }
 
@@ -23,24 +37,34 @@ class ManagementRVAdapter: ListAdapter<UnBookableResult, ManagementRVAdapter.Man
         holder.bind(currentList[position])
     }
 
-    inner class ManagementViewHolder(private val binding: ItemManagementCalnedarBinding) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: UnBookableResult) {
+    inner class ManagementViewHolder(private val binding: ItemManagementCalnedarBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: UnavailableDateInfo) {
+            val formattedStartDate = item.getFormattedStartDate()
+            val formattedEndDate = item.getFormattedEndDate()
+
             binding.unAvailableDate = item
+            binding.unavailableDateTextView.text = "$formattedStartDate~$formattedEndDate"
+
+
+            binding.unavailableClearButton.setOnClickListener {
+                onDeleteClickListener.onDeleteClick(item.FarmDateID)
+            }
         }
     }
 
     companion object {
-        val diffUtil = object : DiffUtil.ItemCallback<UnBookableResult>() {
+        val diffUtil = object : DiffUtil.ItemCallback<UnavailableDateInfo>() {
             override fun areItemsTheSame(
-                oldItem: UnBookableResult,
-                newItem: UnBookableResult
+                oldItem: UnavailableDateInfo,
+                newItem: UnavailableDateInfo
             ): Boolean {
                 return oldItem === newItem
             }
 
             override fun areContentsTheSame(
-                oldItem: UnBookableResult,
-                newItem: UnBookableResult
+                oldItem: UnavailableDateInfo,
+                newItem: UnavailableDateInfo
             ): Boolean {
                 return oldItem == newItem
             }

--- a/app/src/main/java/com/farm/farmus_application/viewmodel/farm/ManagementCalendarViewModel.kt
+++ b/app/src/main/java/com/farm/farmus_application/viewmodel/farm/ManagementCalendarViewModel.kt
@@ -1,0 +1,101 @@
+package com.farm.farmus_application.viewmodel.farm
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailableDateAdditionReq
+import com.farm.farmus_application.model.farm.unavailableDate.UnavailableDateInfo
+import com.farm.farmus_application.repository.farm.FarmDataSourceInterface
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// 아키텍처 구조가 잘못 잡혀 있어서.. 이상하긴 하지만 원래는 Repo interface를 넘겨서 해야함.
+// DataSrcInterface라고 명명되어있지만 사실 Repo interface임.
+@HiltViewModel
+class ManagementCalendarViewModel @Inject constructor(
+    private val farmRepository: FarmDataSourceInterface,
+) : ViewModel() {
+    private val TAG = "ManagementCalendarViewModel"
+
+    private val _isSuccessAddDate = MutableLiveData<Boolean>()
+    val isSuccessAddDate: LiveData<Boolean> get() = _isSuccessAddDate
+
+    private val _unavailableDateInfoList = MutableLiveData<List<UnavailableDateInfo>>()
+    val unavailableDateInfoList: LiveData<List<UnavailableDateInfo>> = _unavailableDateInfoList
+
+    private val _isSuccessDeleteDate = MutableLiveData<Boolean>()
+    val isSuccessDeleteDate: LiveData<Boolean> = _isSuccessDeleteDate
+
+    private val _errorMessage = MutableLiveData<String>() // 에러 메시지 전달용 LiveData
+    val errorMessage: LiveData<String> = _errorMessage
+
+    fun addUnavailableDate(farmID: Int, unavailableStartDate: String, unavailableEndDate: String) {
+        viewModelScope.launch {
+            try {
+                // Retrofit 이용해서 API 호출 (로컬 정보를 서버로 보냄)
+                val response = farmRepository.postUnavailableDate(
+                    UnavailableDateAdditionReq(farmID, unavailableStartDate, unavailableEndDate)
+                )
+                if (response.isSuccessful) {
+                    // message와 farmDateID에 대한 처리 필요
+                    response.body()?.let {
+                        _isSuccessAddDate.postValue(it.isSuccess)
+
+                        // 추가가 성공적으로 이루어지면 목록을 업데이트(UI 바로 반영)
+                        if (it.isSuccess) {
+                            getUnavailableDateList(farmID)
+                        }
+
+                    }
+                } else {
+                    _errorMessage.value = "이용 불가 기간 추가에 오류가 있습니다."
+                    Log.e(TAG, response.errorBody()?.string() ?: response.message())
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+    fun deleteUnavailableDate(farmDateID: Int, farmID: Int) {
+        viewModelScope.launch {
+            try {
+                val response = farmRepository.putDeleteUnavailableDate(farmDateID)
+                response.body()?.let {
+                    if (it.isSuccess) {
+                        _isSuccessDeleteDate.postValue(true)
+                        getUnavailableDateList(farmID)
+                    } else {
+                        _errorMessage.value = "삭제에 문제가 발생했습니다."
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+
+    }
+
+    fun getUnavailableDateList(farmID: Int) {
+        viewModelScope.launch {
+            try {
+                val response = farmRepository.getUnavailableDate(farmID)
+                response.body()?.let {
+                    if (it.isSuccess) {
+                        _unavailableDateInfoList.postValue(it.result)
+                    } else {
+                        _errorMessage.value = "이용 불가 기간 목록을 불러오는 데 문제가 발생했습니다."
+                        Log.e(TAG, response.errorBody()?.string() ?: response.message())
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
+
+
+}

--- a/app/src/main/res/layout/item_management_calnedar.xml
+++ b/app/src/main/res/layout/item_management_calnedar.xml
@@ -6,7 +6,7 @@
     <data>
         <variable
             name="unAvailableDate"
-            type="com.farm.farmus_application.model.reserve.unbookable.UnBookableResult" />
+            type="com.farm.farmus_application.model.farm.unavailableDate.UnavailableDateInfo" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -21,7 +21,6 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="15dp"
             android:textColor="@color/text_1"
-            android:text="@{unAvailableDate.startAt}"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/unavailableClearButton"
             app:layout_constraintBottom_toBottomOf="@id/unavailableClearButton"


### PR DESCRIPTION
## 구현한 기능
농장주(farmer)가 농장 이용 불가 기간을 추가하고 삭제하는 코드
이용 불가 기간 추가 삭제에 따라 '농장주'의 해당 달력에 해당 기간에 표기가 됨.

## 사용한 라이브러리 및 Class
ManagementCalendarFragment와 ViewModel 관련 코드 부분

## 문제점과 예상 원인
28일에서 30일로 날짜를 add했지만, 아마도 서버에서 27일에서 29일로 변경되어 저장되는 문제가 있습니다.<br>
안드로이드 파트 전반에 걸쳐서 정보를 보여줄 때, 서버의 정보를 그대로 가져와서 보여주고 있습니다.
이에 이용 등록 불가 기간을 보여주는 리사이클러 뷰 내부의 아이템들(삭제 버튼을 가진 것들)과 달력 그 자체에 block 처리 되는 부분에서 서버의 정보와 동일하게 처리가 되어 하루씩 덜 처리되는 문제가 있습니다. <br>
이에 대한 해결 방안으로 서버와 시간을 맞추는 로직이 필요합니다. 현재 상황에선 서버의 것들을 그대로 가져와 보여주기 때문에 서버에서 국내 시간으로 맞춰 보내주어야 합니다.